### PR TITLE
fix: ddb characters have seemingly added a new item classSpells.

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -640,11 +640,12 @@ const convertItems = (ddbCharacter: DdbCharacter): AlchemyItem[] => {
 
 // Convert all spells except those granted by items to Alchemy format
 const convertSpells = (ddbCharacter: DdbCharacter): AlchemySpell[] => {
-  return Object.entries(ddbCharacter.spells)
+  return [...Object.entries(ddbCharacter.spells)
     .filter(([origin, spells]) => origin !== "item" && spells)
     .flatMap(([_origin, spells]) => spells)
-    .filter(spell => spell.definition)
-    .map(convertSpell)
+    .filter(spell => spell.definition),
+  ...ddbCharacter.classSpells.reduce((classSpellList, classSpellBlock) => ([...classSpellList, ...classSpellBlock.spells] as DdbSpell[]), [] as DdbSpell[])
+  ].map(convertSpell)
 }
 
 // Convert a spell to Alchemy format
@@ -652,7 +653,7 @@ const convertSpell = (ddbSpell: DdbSpell): AlchemySpell => {
   const spell = ddbSpell.definition
 
   // If the spell is in the SRD, let Alchemy populate its data
-  if (spell.sources.some(source => source.sourceId === 1)) return {
+  if (spell.sources.some(source => source.sourceId === 1 && source.pageNumber !== null)) return {
     name: spell.name,
   }
 

--- a/src/ddb.ts
+++ b/src/ddb.ts
@@ -61,6 +61,11 @@ export interface DdbCharacter {
   }
   spellSlots: DdbSpellSlot[],
   feats: DdbFeat[],
+  classSpells: {
+    entityTypeId: number;
+    characterClassId: number;
+    spells: DdbSpell[];
+  }[]
 }
 
 interface DdbStat {


### PR DESCRIPTION
This fix will make it possible to also parse those classSpells

Background:
I was wondering why my transferred characters were missing some spells.
When I compared the json files, I found that the converter was not checking the "classSpells" attribute.

I don't know if this was by design, or a change on dndbeyonds side, but this change should fix it.