### PR TITLE
Ignore custom spell component types when converting spells

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -676,7 +676,7 @@ const convertSpell = (ddbSpell: DdbSpell): AlchemySpell => {
     school: spell.school,
     canCastAtHigherLevel: spell.canCastAtHigherLevel,
     castingTime: convertSpellCastingTime(ddbSpell),
-    components: spell.components.map(c => DDB_SPELL_COMPONENT_TYPE[c][0]),
+    components: spell.components.filter(c => c <= 3).map(c => DDB_SPELL_COMPONENT_TYPE[c][0]),
     duration: convertSpellDuration(ddbSpell),
     requiresConcentration: spell.concentration,
     canBeCastAsRitual: spell.ritual,


### PR DESCRIPTION
Evidently some spells on D&D Beyond can have component types
outside of the standard verbal/somatic/material. This ensures
we don't attempt to carry over those components to Alchemy.

Fixes #24
