### PR TITLE
Support converting custom character backgrounds

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -545,13 +545,24 @@ const getTextBlocks = (ddbCharacter: DdbCharacter): AlchemyTextBlockSection[] =>
   })
 
   // background
-  textBlocks.push({
-    title: "Background",
-    textBlocks: [{
-      title: ddbCharacter.background.definition.name,
-      body: turndownService.turndown(ddbCharacter.background.definition.description),
-    }]
-  })
+  if (ddbCharacter.background.hasCustomBackground) {
+    textBlocks.push({
+      title: "Background",
+      textBlocks: [{
+        title: ddbCharacter.background.customBackground.name,
+        body: turndownService.turndown(ddbCharacter.background.customBackground.description),
+      }]
+    })
+  }
+  else {
+    textBlocks.push({
+      title: "Background",
+      textBlocks: [{
+        title: ddbCharacter.background.definition.name,
+        body: turndownService.turndown(ddbCharacter.background.definition.description),
+      }]
+    })
+  }
 
   // characteristics
   textBlocks.push({

--- a/src/ddb.ts
+++ b/src/ddb.ts
@@ -294,10 +294,15 @@ interface DdbTrait {
 }
 
 interface DdbBackground {
+  hasCustomBackground: boolean,
   definition: {
     name: string,
     description: string,
     shortDescription: string,
+  }
+  customBackground: {
+    name: string,
+    description: string,
   }
 }
 


### PR DESCRIPTION
If a custom background is set, use its title and description when
converting to Alchemy format.

Fixes #20
