### PR TITLE
Handle characters with no background when converting

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -554,13 +554,19 @@ const getTextBlocks = (ddbCharacter: DdbCharacter): AlchemyTextBlockSection[] =>
       }]
     })
   }
-  else {
+  else if (ddbCharacter.background.definition) {
     textBlocks.push({
       title: "Background",
       textBlocks: [{
         title: ddbCharacter.background.definition.name,
         body: turndownService.turndown(ddbCharacter.background.definition.description),
       }]
+    })
+  }
+  else {
+    textBlocks.push({
+      title: "Background",
+      textBlocks: []
     })
   }
 


### PR DESCRIPTION
Fixes an issue reported by Carlos in discord where a character
would not convert because it had no background assigned.

Tested on https://www.dndbeyond.com/characters/60851022
