### PR TITLE
Strip HTML from Speed racial trait when converting

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -481,7 +481,7 @@ const getMovementModes = (ddbCharacter: DdbCharacter): AlchemyMovementMode[] => 
     .filter(trait => trait.definition.name === "Speed")
     .map(trait => {
       // Try to parse a speed from the trait description
-      const matches = trait.definition.description.match(DDB_SPEED_RE)
+      const matches = cleanHtml(trait.definition.description).match(DDB_SPEED_RE)
       if (!matches) return
 
       // Convert movement mode to Alchemy format


### PR DESCRIPTION
Fixes an issue reported by Carlos in Discord where conversion fails
because the Speed racial trait includes markup that prevents our
regex from detecting the character's base speed.

Tested on https://www.dndbeyond.com/characters/60851022
