### PR TITLE
Convert all movement modes and include bonuses

### DIFF
--- a/src/ddb.ts
+++ b/src/ddb.ts
@@ -306,7 +306,8 @@ interface DdbBackground {
   }
 }
 
-export const DDB_SPEED_RE = /(\S+) speed (?:is|of) (\d+)/i
+export const DDB_SPEED_IS_RE = /(\S+) speed (?:is|of) (\d+)/i
+export const DDB_SPEED_EQUALS_RE = /(\S+) speed equal to your (\S+) speed/i
 
 interface DdbFeat {
   definition: {


### PR DESCRIPTION
This solves an issue originally reported by DragoSinOfWrath on
Discord.

Some speeds listed in racial traits are written as "equal to your
X speed" without giving a flat value, so we needed new logic to
parse those values.

Additionally, items that give bonuses to speed or particular types
of speed were not factored into the conversion of movement modes.
