### PR TITLE
feat: converter options

### DIFF
--- a/test/convert.options.test.ts
+++ b/test/convert.options.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, expect, test } from '@jest/globals';
+import { DEFAULT_ALCHEMY_CHARACTER, convertCharacter } from '../src';
+import * as character from './fixtures/25188288.json';
+
+describe('Conversion with Options', () => {
+    test('should convert entire character when options is NOT passed (undefined)', () => {
+        const converted = convertCharacter(character);
+        expect(converted.name).toEqual(character.name);
+    });
+
+    test('should convert ONLY the name property', () => {
+        const converted = convertCharacter(character, { name: true });
+        expect(converted).toEqual({
+            ...DEFAULT_ALCHEMY_CHARACTER,
+            name: character.name,
+        });
+    });
+});


### PR DESCRIPTION
## Describe your changes
Added types and an extra "options" param to the convertCharacter function so that only the properties specified in the options object are converted.

This is going to aid in writing tests as now we don't need to run all code paths when testing a specific fragment of the conversion code.

## D&D Beyond character link
Uses the included character in the fixtures directory.

## Pre-review checklist
-   [x] I have added a description of my changes
-   [x] I have formatted my code with `yarn format`
-   [x] I have added a link to a D&D Beyond character that can be used to test these changes
-   [x] I have read the [contributing guidelines](CONTRIBUTING.md)
-   [x] I agree to the [code of conduct](CODE_OF_CONDUCT.md)
