### PR TITLE
fixed the "weight" needs to be a string problem

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -300,10 +300,8 @@ export const convertCharacter = (
         convertSpellSlots(ddbCharacter),
     ),
     ...shouldConvert(options, 'textBlocks', () => getTextBlocks(ddbCharacter)),
-    ...shouldConvert(
-        options,
-        'weight',
-        () => ddbCharacter.weight ?? ''.toString(),
+    ...shouldConvert(options, 'weight', () =>
+        ddbCharacter.weight ? ddbCharacter.weight.toString() : '',
     ),
 });
 


### PR DESCRIPTION
## Describe your changes

- `ddbCharater.weight` is a number and the system expects it be a string, converted on to a string if it exists otherwise it would be an empty string.

## D&D Beyond character link

https://www.dndbeyond.com/characters/99603501
https://www.dndbeyond.com/characters/98857388
https://www.dndbeyond.com/characters/7988555/5uCKLU

## Pre-review checklist

-   [x] I have added a description of my changes
-   [x] I have formatted my code with `yarn format`
-   [x] I have added a link to a D&D Beyond character that can be used to test these changes
-   [x] I have read the [contributing guidelines](CONTRIBUTING.md)
-   [x] I agree to the [code of conduct](CODE_OF_CONDUCT.md)
